### PR TITLE
AC0008 - Described the risk of not explicitly setting the `DataPerCompany` table object property

### DIFF
--- a/content/docs/analyzers/ApplicationCop/AC0008.md
+++ b/content/docs/analyzers/ApplicationCop/AC0008.md
@@ -3,7 +3,8 @@ title = 'DataPerCompany must be explicitly set on table objects (AC0008)'
 linkTitle = 'AC0008'
 +++
 
-In projects where company data isolation matters, table objects must explicitly define the DataPerCompany property. Relying on implicit defaults makes the data scope unclear and can lead to incorrect assumptions about whether data is shared across companies or stored per company.
+The `DataPerCompany` property on `table` objects can be used to specify whether there should be a SQL table for each company or a single SQL table used by all companies.
+The implicit default of the `DataPerCompany` property is `true`, which means that if the developer intended it to be `false` but forgets to set it and the solution is released, there is no proper way to resolve this with a future update, i.e., there is no way to decide which values and/or records are the ones that should be retained when changing from a `DataPerCompany = true` table to a `DataPerCompany = false` table.
 
 Explicitly declaring this property ensures that the design intent is clear and documented in the code, preventing data isolation issues in multi-company environments.
 


### PR DESCRIPTION
This PR updates the description of rule AC0008 "DataPerCompany must be explicitly set on table objects", to better explain the risks of not explicitly setting the `DataPerCompany` table object property.

In my opinion relying on the implicit value of this property is a major risk, and I think this rule shouldn't be disabled by default.