### PR TITLE
docs: Add LC0095 - Unused parameter in procedure

### DIFF
--- a/content/docs/analyzers/LinterCop/LC0095.md
+++ b/content/docs/analyzers/LinterCop/LC0095.md
@@ -3,9 +3,11 @@ title = 'Unused parameter in procedure (LC0095)'
 linkTitle = 'LC0095'
 +++
 
-Parameters that are declared but never referenced in the procedure body add noise and maintenance burden. Remove unused parameters or use them in the procedure body.
+CodeCop [AA0137](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137) detects unused parameters only in local procedures and explicitly excludes event subscribers. LC0095 covers the gaps: internal procedures, public procedures, and event subscribers.
 
-This rule extends Microsoft's [CodeCop AA0137](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137) to cover cases that AA0137 does not check. AA0137 only flags unused parameters in **local** procedures (and excludes event subscribers). LC0095 covers the remaining gaps:
+An unused parameter clutters the signature, misleads callers about what the procedure needs, and creates unnecessary coupling. Removing it simplifies both the definition and every call site.
+
+### Covered by this rule
 
 - Internal procedures
 - Public procedures
@@ -13,28 +15,24 @@ This rule extends Microsoft's [CodeCop AA0137](https://learn.microsoft.com/en-us
 
 ### Excluded from this rule
 
-The following are excluded because their parameter signatures cannot be freely changed:
-
-- **Local procedures** (already handled by AA0137)
-- **Triggers** (platform-defined signatures)
+- **Local procedures** (AA0137 handles them)
+- **Triggers** (platform-defined signatures, cannot be changed)
 - **Interface implementations** (bound by interface contract)
 - **Event declarations** (`[IntegrationEvent]`/`[BusinessEvent]`, parameters define the subscriber contract)
-- **Obsolete procedures** (pending or removed)
+- **Obsolete procedures** (pending or removed, not worth modifying)
 
 ### Example
-
-The following public procedure has an unused parameter:
 
 ```al
 codeunit 50100 MyCodeunit
 {
-    procedure MyProcedure(MyVariant: Variant) // Parameter 'MyVariant' is not used [LC0095]
+    procedure MyProcedure(MyVariant: Variant) // Parameter 'MyVariant' is not used in procedure 'MyProcedure'. [LC0095]
     begin
     end;
 }
 ```
 
-To fix this, either use the parameter or remove it:
+Fixed:
 
 ```al
 codeunit 50100 MyCodeunit
@@ -47,13 +45,11 @@ codeunit 50100 MyCodeunit
 
 ### Event subscriber example
 
-Unused parameters in event subscribers are also flagged:
-
 ```al
 codeunit 50100 MyCodeunit
 {
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Post", OnBeforePostSalesDoc, '', false, false)]
-    local procedure OnBeforePostSalesDoc(var SalesHeader: Record "Sales Header"; var IsHandled: Boolean) // 'SalesHeader' unused [LC0095]
+    local procedure OnBeforePostSalesDoc(var SalesHeader: Record "Sales Header"; var IsHandled: Boolean) // Parameter 'SalesHeader' is not used in procedure 'OnBeforePostSalesDoc'. [LC0095]
     begin
         IsHandled := true;
     end;
@@ -62,7 +58,7 @@ codeunit 50100 MyCodeunit
 
 ### Code fix
 
-A quick fix is available to automatically remove the unused parameter from the procedure signature. Note that this does **not** update call sites; callers that pass an argument for the removed parameter will need manual adjustment.
+A quick fix removes the unused parameter from the procedure signature. It does **not** update call sites. Callers that pass an argument for the removed parameter need manual adjustment.
 
 ### Relationship to AA0137
 

--- a/content/docs/analyzers/LinterCop/LC0095.md
+++ b/content/docs/analyzers/LinterCop/LC0095.md
@@ -1,11 +1,11 @@
 +++
-title = 'Unused parameter in procedure (LC0095)'
+title = 'Parameter not referenced (LC0095)'
 linkTitle = 'LC0095'
 +++
 
-CodeCop [AA0137](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137) detects unused parameters only in local procedures and explicitly excludes event subscribers. LC0095 covers the gaps: internal procedures, public procedures, and event subscribers.
+CodeCop [AA0137](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137) detects unreferenced parameters only in local procedures and explicitly excludes event subscribers. LC0095 covers the gaps: internal procedures, public procedures, and event subscribers.
 
-An unused parameter clutters the signature, misleads callers about what the procedure needs, and creates unnecessary coupling. Removing it simplifies both the definition and every call site.
+A parameter that is never referenced in the procedure body clutters the signature, misleads callers about what the procedure needs, and creates unnecessary coupling. Removing it simplifies both the definition and every call site.
 
 ### Covered by this rule
 
@@ -58,7 +58,7 @@ codeunit 50100 MyCodeunit
 
 ### Code fix
 
-A quick fix removes the unused parameter from the procedure signature. It does **not** update call sites. Callers that pass an argument for the removed parameter need manual adjustment.
+A quick fix removes the unreferenced parameter from the procedure signature. It does **not** update call sites. Callers that pass an argument for the removed parameter need manual adjustment.
 
 ### Relationship to AA0137
 

--- a/content/docs/analyzers/LinterCop/LC0095.md
+++ b/content/docs/analyzers/LinterCop/LC0095.md
@@ -1,0 +1,83 @@
++++
+title = 'Unused parameter in procedure (LC0095)'
+linkTitle = 'LC0095'
++++
+
+Parameters that are declared but never referenced in the procedure body add noise and maintenance burden. Remove unused parameters or use them in the procedure body.
+
+This rule extends Microsoft's [CodeCop AA0137](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137) to cover cases that AA0137 does not check. AA0137 only flags unused parameters in **local** procedures (and excludes event subscribers). LC0095 covers the remaining gaps:
+
+- Internal procedures
+- Public procedures
+- Event subscribers
+
+### Excluded from this rule
+
+The following are excluded because their parameter signatures cannot be freely changed:
+
+- **Local procedures** (already handled by AA0137)
+- **Triggers** (platform-defined signatures)
+- **Interface implementations** (bound by interface contract)
+- **Event declarations** (`[IntegrationEvent]`/`[BusinessEvent]`, parameters define the subscriber contract)
+- **Obsolete procedures** (pending or removed)
+
+### Example
+
+The following public procedure has an unused parameter:
+
+```al
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(MyVariant: Variant) // Parameter 'MyVariant' is not used [LC0095]
+    begin
+    end;
+}
+```
+
+To fix this, either use the parameter or remove it:
+
+```al
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    begin
+    end;
+}
+```
+
+### Event subscriber example
+
+Unused parameters in event subscribers are also flagged:
+
+```al
+codeunit 50100 MyCodeunit
+{
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Post", OnBeforePostSalesDoc, '', false, false)]
+    local procedure OnBeforePostSalesDoc(var SalesHeader: Record "Sales Header"; var IsHandled: Boolean) // 'SalesHeader' unused [LC0095]
+    begin
+        IsHandled := true;
+    end;
+}
+```
+
+### Code fix
+
+A quick fix is available to automatically remove the unused parameter from the procedure signature. Note that this does **not** update call sites; callers that pass an argument for the removed parameter will need manual adjustment.
+
+### Relationship to AA0137
+
+| Scope | AA0137 | LC0095 |
+|---|---|---|
+| Local procedures | ✅ | ❌ (defers to AA0137) |
+| Internal procedures | ❌ | ✅ |
+| Public procedures | ❌ | ✅ |
+| Event subscribers | ❌ | ✅ |
+| Triggers | ❌ | ❌ |
+| Interface implementations | ❌ | ❌ |
+| Event declarations | ❌ | ❌ |
+
+### See also
+
+- [AA0137 - Do not declare variables that are unused](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137)
+- [LC0052](../lc0052/) - Internal procedure not referenced
+- [LC0053](../lc0053/) - Internal procedure only used in current object

--- a/content/docs/analyzers/LinterCop/_index.md
+++ b/content/docs/analyzers/LinterCop/_index.md
@@ -37,4 +37,5 @@ The LinterCop is a code linter for AL, comparable to widely used static analysis
 | [LC0091](lc0091/) | Translatable text should be translated | Warning | ✓ | |
 | [LC0092](lc0092/) | Name does not match naming convention | Warning | ✓ | |
 | [LC0094](lc0094/) | AllowInCustomizations redundancy | Warning | ✓ | ✓ |
+| [LC0095](lc0095/) | Unused parameter in procedure | Warning | ✓ | ✓ |
 | [LC0096](lc0096/) | Unnecessary record parameter in method call | Warning | ✓ | |

--- a/content/docs/analyzers/LinterCop/_index.md
+++ b/content/docs/analyzers/LinterCop/_index.md
@@ -37,5 +37,5 @@ The LinterCop is a code linter for AL, comparable to widely used static analysis
 | [LC0091](lc0091/) | Translatable text should be translated | Warning | ✓ | |
 | [LC0092](lc0092/) | Name does not match naming convention | Warning | ✓ | |
 | [LC0094](lc0094/) | AllowInCustomizations redundancy | Warning | ✓ | ✓ |
-| [LC0095](lc0095/) | Unused parameter in procedure | Warning | ✓ | ✓ |
+| [LC0095](lc0095/) | Parameter not referenced | Warning | ✓ | ✓ |
 | [LC0096](lc0096/) | Unnecessary record parameter in method call | Warning | ✓ | |


### PR DESCRIPTION
Adds documentation page for the new LC0095 diagnostic rule.

This rule extends CodeCop AA0137 to cover unused parameters in internal/public procedures and event subscribers.

Related: ALCops/Analyzers#145, ALCops/Analyzers#238