### PR TITLE
docs(PC0014): Add SelectTokens examples and mention all Json types

### DIFF
--- a/content/docs/analyzers/PlatformCop/PC0014.md
+++ b/content/docs/analyzers/PlatformCop/PC0014.md
@@ -5,9 +5,11 @@ linkTitle = 'PC0014'
 
 When using JPath expressions to query JSON, string values within the path should use double quotes, not single quotes. Single quotes in JPath expressions may not work correctly.
 
+This rule applies to the `SelectToken` and `SelectTokens` methods on `JsonToken`, `JsonObject`, and `JsonArray`.
+
 A code fix is available for this diagnostic.
 
-### Example
+### Example: SelectToken
 
 The following code uses single quotes in JPath:
 
@@ -35,6 +37,38 @@ codeunit 50100 MyCodeunit
         JsonToken: JsonToken;
     begin
         JsonObject.SelectToken('$[?(@.name=="John")]', JsonToken);
+    end;
+}
+```
+
+### Example: SelectTokens
+
+The same rule applies to `SelectTokens`:
+
+```al
+codeunit 50100 MyCodeunit
+{
+    procedure ReadJson()
+    var
+        MyJsonToken: JsonToken;
+        Results: List of [JsonToken];
+    begin
+        MyJsonToken.SelectTokens('$.items[?(@.status==''active'')]', Results); // JsonToken JPath uses double quotes [PC0014]
+    end;
+}
+```
+
+To fix this, use double quotes:
+
+```al
+codeunit 50100 MyCodeunit
+{
+    procedure ReadJson()
+    var
+        MyJsonToken: JsonToken;
+        Results: List of [JsonToken];
+    begin
+        MyJsonToken.SelectTokens('$.items[?(@.status=="active")]', Results);
     end;
 }
 ```


### PR DESCRIPTION
Expands the PC0014 rule page with SelectTokens examples and covers all Json types.

Split from #75.