### PR TITLE
docs: fix PC0026 documentation to match analyzer behavior

### DIFF
--- a/content/docs/analyzers/PlatformCop/PC0026.md
+++ b/content/docs/analyzers/PlatformCop/PC0026.md
@@ -16,7 +16,7 @@ A code fix is available for this diagnostic.
 
 The following API page is missing the mandatory fields:
 
-{{< highlight al "hl_lines=3" >}}
+```al
 page 50100 "My API Page"
 {
     PageType = API;
@@ -30,7 +30,7 @@ page 50100 "My API Page"
         }
     }
 }
-{{< /highlight >}}
+```
 
 To fix this, add the `id` and `lastModifiedDateTime` fields:
 
@@ -56,7 +56,7 @@ page 50100 "My API Page"
 
 The webhook system in Business Central explicitly looks for a page control named `lastModifiedDateTime` to determine whether change tracking is supported:
 
-```al
+{{< highlight al "hl_lines=8" >}}
 // From Base Application codeunit "API Webhook Notification Send"
 local procedure HasLastModifiedDateTimeField(var APIWebhookSubscription: Record "API Webhook Subscription"): Boolean
 var
@@ -67,11 +67,11 @@ begin
     PageControlField.SetRange(ControlName, 'lastModifiedDateTime');
     ...
 end;
-```
+{{< /highlight >}}
 
 Without this field, the platform cannot send incremental webhook notifications for your API page.
 
 ### Related content
 
-- [API Page / Query best practices (alguidelines.dev)](https://alguidelines.dev/docs/bestpractices/api-page/)
-- [BC source: APIWebhookNotificationSend.Codeunit.al](https://github.com/StefanMaron/MSDyn365BC.Sandbox.Code.History/blob/w1-28/Base%20Application/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al)
+- [API Page / Query best practices | alguidelines.dev](https://alguidelines.dev/docs/bestpractices/api-page/#mandatory-fields)
+- [APIWebhookNotificationSend.Codeunit.al | MSDyn365BC.Sandbox.Code.History](https://github.com/StefanMaron/MSDyn365BC.Sandbox.Code.History/blob/w1-28/Base%20Application/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al)

--- a/content/docs/analyzers/PlatformCop/PC0026.md
+++ b/content/docs/analyzers/PlatformCop/PC0026.md
@@ -3,33 +3,20 @@ title = 'Mandatory field missing on API page (PC0026)'
 linkTitle = 'PC0026'
 +++
 
-API pages should expose certain mandatory fields like SystemId, SystemCreatedAt, SystemCreatedBy, SystemModifiedAt, and SystemModifiedBy. These fields are important for API consumers to track record metadata.
+API pages must expose two mandatory system fields:
+
+- `SystemId` exposed with the name `id`
+- `SystemModifiedAt` exposed with the name `lastModifiedDateTime`
+
+The `id` field uniquely identifies each record for API consumers. The `lastModifiedDateTime` field is required for webhook support: the Business Central webhook infrastructure filters change notifications using this exact field name. If you choose a different name, webhook notifications will not work properly.
 
 A code fix is available for this diagnostic.
 
 ### Example
 
-The following API page is missing mandatory fields:
+The following API page is missing the mandatory fields:
 
-```al
-page 50100 "My API Page"
-{
-    PageType = API;
-    SourceTable = Customer; // Mandatory field missing on API page [PC0026]
-
-    layout
-    {
-        area(Content)
-        {
-            field(name; Rec.Name) { }
-        }
-    }
-}
-```
-
-To fix this, add the mandatory system fields:
-
-```al
+{{< highlight al "hl_lines=3" >}}
 page 50100 "My API Page"
 {
     PageType = API;
@@ -39,13 +26,52 @@ page 50100 "My API Page"
     {
         area(Content)
         {
-            field(systemId; Rec.SystemId) { }
             field(name; Rec.Name) { }
-            field(systemCreatedAt; Rec.SystemCreatedAt) { }
-            field(systemCreatedBy; Rec.SystemCreatedBy) { }
-            field(systemModifiedAt; Rec.SystemModifiedAt) { }
-            field(systemModifiedBy; Rec.SystemModifiedBy) { }
         }
     }
 }
+{{< /highlight >}}
+
+To fix this, add the `id` and `lastModifiedDateTime` fields:
+
+{{< highlight al "hl_lines=10 12" >}}
+page 50100 "My API Page"
+{
+    PageType = API;
+    SourceTable = Customer;
+
+    layout
+    {
+        area(Content)
+        {
+            field(id; Rec.SystemId) { }
+            field(name; Rec.Name) { }
+            field(lastModifiedDateTime; Rec.SystemModifiedAt) { }
+        }
+    }
+}
+{{< /highlight >}}
+
+### Deep dive
+
+The webhook system in Business Central explicitly looks for a page control named `lastModifiedDateTime` to determine whether change tracking is supported:
+
+```al
+// From Base Application codeunit "API Webhook Notification Send"
+local procedure HasLastModifiedDateTimeField(var APIWebhookSubscription: Record "API Webhook Subscription"): Boolean
+var
+    PageControlField: Record "Page Control Field";
+begin
+    ...
+    PageControlField.SetRange(PageNo, ApiWebhookEntity."Object ID");
+    PageControlField.SetRange(ControlName, 'lastModifiedDateTime');
+    ...
+end;
 ```
+
+Without this field, the platform cannot send incremental webhook notifications for your API page.
+
+### Related content
+
+- [API Page / Query best practices (alguidelines.dev)](https://alguidelines.dev/docs/bestpractices/api-page/)
+- [BC source: APIWebhookNotificationSend.Codeunit.al](https://github.com/StefanMaron/MSDyn365BC.Sandbox.Code.History/blob/w1-28/Base%20Application/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al)


### PR DESCRIPTION
## Summary

Fixes #100

The PC0026 documentation incorrectly listed 5 mandatory system fields. The analyzer source only requires **two**:
- `SystemId` exposed as `id`
- `SystemModifiedAt` exposed as `lastModifiedDateTime`

## Changes

- Corrected the mandatory fields to match the analyzer implementation
- Added clear examples showing the required exposed field names
- Added a "Deep dive" section with a code snippet from `APIWebhookNotificationSend` showing why `lastModifiedDateTime` must be named exactly that
- Added link to [alguidelines.dev API page best practices](https://alguidelines.dev/docs/bestpractices/api-page/)
- Added link to [BC source](https://github.com/StefanMaron/MSDyn365BC.Sandbox.Code.History/blob/w1-28/Base%20Application/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al)