### PR TITLE
docs(LC0092): document enum value opt-in naming check

### DIFF
--- a/content/docs/analyzers/LinterCop/LC0092.md
+++ b/content/docs/analyzers/LinterCop/LC0092.md
@@ -46,7 +46,7 @@ The rule checks the following naming targets, each with a default convention:
 | Object | Must start with an uppercase letter | Tables, pages, codeunits, reports, queries, XmlPorts, enums, interfaces, permission sets |
 | Field | Must start with a letter (upper or lower); must not contain %, &, !, ? | Table fields |
 | Action | Must start with an uppercase letter | Page actions |
-| EnumValue | Must start with an uppercase letter | Enum values |
+| EnumValue | No default (opt-in only) | Enum values |
 | Control | Must start with an uppercase letter | Page controls |
 
 These conventions are implemented as regex patterns under the hood (`^[A-Z]`, `^[A-Za-z]`, `[%&!?]`). You can override them with custom patterns in `alcops.json` (see [Configuration](#configuration)).
@@ -61,6 +61,22 @@ These conventions are implemented as regex patterns under the hood (`^[A-Z]`, `^
 - The method is a trigger (platform-defined name)
 - The method implements an interface (can't change the name)
 - Object names have AppSourceCop affixes stripped before checking
+- **Enum values** are not checked by default (opt-in only)
+
+### Opting in to enum value checks
+
+Enum value naming is not checked by default because enum values starting with digits (e.g., `"1 Day"`, `"30 Days"`) are common in AL and not prohibited by Microsoft guidelines. To enable enum value naming checks, configure it explicitly in `alcops.json`:
+
+```json
+{
+    "NamingPatterns": {
+        "EnumValue": {
+            "AllowPattern": "^[A-Z]",
+            "AllowDescription": "should start with an uppercase letter"
+        }
+    }
+}
+```
 
 ### Configuration
 


### PR DESCRIPTION
Related: ALCops/Analyzers#321, ALCops/Analyzers#324

## Changes
- Updated the naming targets table: EnumValue is now "No default (opt-in only)"
- Added a new section explaining why enum values aren't checked by default
- Added opt-in example showing how to configure via `alcops.json`