### PR TITLE
DC0006, DC0007-DC0010 Documentation Cop

### DIFF
--- a/content/docs/analyzers/DocumentationCop/DC0005.md
+++ b/content/docs/analyzers/DocumentationCop/DC0005.md
@@ -59,4 +59,4 @@ The diagnostic fires only when XML documentation comments already exist on the p
 
 ### See also
 
-- [DC0004](../dc0004/) — Public procedures must have XML documentation
+- [DC0004](../dc0004/) — Public procedures must include XML documentation comments

--- a/content/docs/analyzers/DocumentationCop/DC0006.md
+++ b/content/docs/analyzers/DocumentationCop/DC0006.md
@@ -1,27 +1,27 @@
 +++
-title = 'Public procedures must include XML documentation comments'
-linkTitle = 'DC0004'
+title = 'Internal procedures must include XML documentation comments'
+linkTitle = 'DC0006'
 
 [params]
-  id = 'DC0004'
-  severity = 'Info'
+  id = 'DC0006'
+  severity = 'Hidden'
   category = 'Design'
   codeAction = false
   ignoreObsolete = true
 +++
 
-A developer adds a public procedure to a codeunit, expecting the procedure name and parameters to speak for themselves. For consumers of the extension — especially those without access to the source code — the procedure appears in IntelliSense with no description, no parameter hints, and no return-value documentation. They are left to guess at its purpose, preconditions, and guarantees.
+A developer adds an internal procedure to a codeunit, expecting the procedure name and parameters to speak for themselves. For consumers of the extension — especially those without access to the source code — the procedure appears in IntelliSense with no description, no parameter hints, and no return-value documentation. They are left to guess at its purpose, preconditions, and guarantees.
 
-Add [XML documentation comments](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments) to describe the procedure, or restrict it to `local` or `internal` scope if it is not meant to be part of the public API.
+Add [XML documentation comments](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments) to describe the procedure, or restrict it to `local` scope if it is not meant to be part of the public API.
 
 ### Example
 
-The following procedure is public but lacks XML documentation:
+The following procedure is internal and lacks XML documentation:
 
 {{< highlight al "hl_lines=3" >}}
 codeunit 50100 MyCodeunit
 {
-    procedure CalculateTotal(Quantity: Decimal; UnitPrice: Decimal): Decimal // Public procedures must include XML documentation comments [DC0004]
+    internal procedure CalculateTotal(Quantity: Decimal; UnitPrice: Decimal): Decimal // Internal procedures must include XML documentation comments [DC0006]
     begin
         exit(Quantity * UnitPrice);
     end;
@@ -39,14 +39,14 @@ codeunit 50100 MyCodeunit
     /// <param name="Quantity">The number of units.</param>
     /// <param name="UnitPrice">The price per unit.</param>
     /// <returns>The total price.</returns>
-    procedure CalculateTotal(Quantity: Decimal; UnitPrice: Decimal): Decimal
+    internal procedure CalculateTotal(Quantity: Decimal; UnitPrice: Decimal): Decimal
     begin
         exit(Quantity * UnitPrice);
     end;
 }
 {{< /highlight >}}
 
-If the procedure is not meant to be called externally, restrict its scope instead:
+If the procedure is not meant to be called externally, restrict its scope instead or limit or remove the `internalsVisibleTo` setting in your `app.json` file (see [app.json file](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-json-files#appjson-file)):
 
 {{< highlight al "hl_lines=3" >}}
 codeunit 50100 MyCodeunit
@@ -60,9 +60,8 @@ codeunit 50100 MyCodeunit
 
 ### When the diagnostic is reported
 
-- The procedure has no `local` or `internal` keyword.
+- The procedure has no `local` keyword or is public and it is not contained in an object with `Access = Internal`.
 - The procedure has no XML documentation comments.
-- The containing object has public accessibility (the default for codeunits). Procedures in a codeunit with `Access = Internal` are not flagged, because they are not part of the extension's public API.
 
 ### Code documentation comments
 
@@ -74,4 +73,5 @@ Test codeunits (`Subtype = Test`) are exempt. Procedures in test codeunits — i
 
 ### See also
 
+- [DC0004](../dc0004/) — Public procedures must include XML documentation comments
 - [DC0005](../dc0005/) — XML documentation must match the procedure signature

--- a/content/docs/analyzers/DocumentationCop/DC0007.md
+++ b/content/docs/analyzers/DocumentationCop/DC0007.md
@@ -1,0 +1,67 @@
++++
+title = 'Public objects must include XML documentation comments'
+linkTitle = 'DC0007'
+
+[params]
+  id = 'DC0007'
+  severity = 'Info'
+  category = 'Design'
+  codeAction = false
+  ignoreObsolete = true
++++
+
+A developer creates a public object, assuming its name will be self-explanatory. For consumers of the extension — especially those without access to the source code — the object appears in IntelliSense with no description and no indication of its purpose or intended usage. They are left to guess when and how to use the object safely.
+
+Add [XML documentation comments](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments) to describe the object, its responsibilities, and any important usage guidance, or restrict its access if it is not meant to be part of the public API.
+
+### Example
+
+The following object is public and lacks XML documentation:
+
+{{< highlight al "hl_lines=1,4" >}}
+codeunit 50100 MyCodeunit // Public objects must include XML documentation comments [DC0007]
+{
+    Access = Public;
+
+    // [...]
+}
+{{< /highlight >}}
+
+Or, when `Access` is omitted, the object is public by default:
+
+{{< highlight al "hl_lines=1" >}}
+codeunit 50100 MyCodeunit // Public objects must include XML documentation comments [DC0007]
+{
+    // [...]
+}
+{{< /highlight >}}
+
+Add XML documentation to describe the object's purpose:
+
+{{< highlight al "hl_lines=1-4" >}}
+/// <summary>
+/// Provides functionality for calculating totals and exposing related business logic.
+/// </summary>
+codeunit 50100 MyCodeunit
+{
+    // [...]
+}
+{{< /highlight >}}
+
+### When the diagnostic is reported
+
+- The object has no `Access` property or is declared with `Access = Public`.
+- The object has no XML documentation comments immediately preceding its declaration.
+
+### Code documentation comments
+
+The AL Language extension has built-in IntelliSense support for [XML documentation comments](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments): typing `///` above an object declaration generates a template with a `<summary>` tag. Code documentation comments are available since [Business Central 2020 Release Wave 2 (version 17)](https://learn.microsoft.com/en-us/previous-versions/dynamics365-release-plan/2020wave2/smb/dynamics365-business-central/code-documentation-comments).
+
+### Exception
+
+Test objects (for example, test codeunits with `Subtype = Test`) are exempt. Public test objects do not require XML documentation.
+
+### See also
+
+- [DC0008](../dc0008/) — Internal objects must include XML documentation comments
+- [DC0004](../dc0004/) — Public procedures must include XML documentation comments

--- a/content/docs/analyzers/DocumentationCop/DC0007.md
+++ b/content/docs/analyzers/DocumentationCop/DC0007.md
@@ -18,7 +18,7 @@ Add [XML documentation comments](https://learn.microsoft.com/dynamics365/busines
 
 The following object is public and lacks XML documentation:
 
-{{< highlight al "hl_lines=1,4" >}}
+{{< highlight al "hl_lines=1 4" >}}
 codeunit 50100 MyCodeunit // Public objects must include XML documentation comments [DC0007]
 {
     Access = Public;

--- a/content/docs/analyzers/DocumentationCop/DC0008.md
+++ b/content/docs/analyzers/DocumentationCop/DC0008.md
@@ -1,0 +1,62 @@
++++
+title = 'Internal objects must include XML documentation comments'
+linkTitle = 'DC0008'
+
+[params]
+  id = 'DC0008'
+  severity = 'Hidden'
+  category = 'Design'
+  codeAction = false
+  ignoreObsolete = true
++++
+
+A developer creates an internal object, assuming that because it is not public, documentation is unnecessary. However, internal objects are often consumed by other objects within the same extension, or by other extensions via `InternalsVisibleTo`. Without XML documentation, consumers see the object in IntelliSense with no description and no guidance on its responsibilities, constraints, or intended usage.
+
+Add [XML documentation comments](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments) to describe the internal object and how it should be used, or restrict it further if it is not meant to be reused.
+
+### Example
+
+The following object is internal and lacks XML documentation:
+
+{{< highlight al "hl_lines=1,4" >}}
+codeunit 50100 MyCodeunit // Internal objects must include XML documentation comments [DC0008]
+{
+    Access = Internal;
+
+    // [...]
+}
+{{< /highlight >}}
+
+Add XML documentation to describe the internal object's purpose:
+
+{{< highlight al "hl_lines=1-4" >}}
+/// <summary>
+/// Provides shared internal functionality for calculating totals and related operations.
+/// </summary>
+codeunit 50100 MyCodeunit
+{
+    Access = Internal;
+
+    // [...]
+}
+{{< /highlight >}}
+
+If the object is not meant to be consumed by other objects, consider reducing its visibility (for example, by moving logic into local procedures inside a more appropriate object).
+
+### When the diagnostic is reported
+
+- The object is declared with `Access = Internal`.
+- The object has no XML documentation comments immediately preceding its declaration.
+
+### Code documentation comments
+
+The AL Language extension has built-in IntelliSense support for [XML documentation comments](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments): typing `///` above an object declaration generates a template with a `<summary>` tag. Code documentation comments are available since [Business Central 2020 Release Wave 2 (version 17)](https://learn.microsoft.com/en-us/previous-versions/dynamics365-release-plan/2020wave2/smb/dynamics365-business-central/code-documentation-comments).
+
+### Exception
+
+Test objects (for example, test codeunits with `Subtype = Test`) are exempt. Internal test objects do not require XML documentation.
+
+### See also
+
+- [DC0007](../dc0007/) — Public objects must include XML documentation comments
+- [DC0006](../dc0006/) — Internal procedures must include XML documentation comments

--- a/content/docs/analyzers/DocumentationCop/DC0008.md
+++ b/content/docs/analyzers/DocumentationCop/DC0008.md
@@ -18,7 +18,7 @@ Add [XML documentation comments](https://learn.microsoft.com/dynamics365/busines
 
 The following object is internal and lacks XML documentation:
 
-{{< highlight al "hl_lines=1,4" >}}
+{{< highlight al "hl_lines=1 4" >}}
 codeunit 50100 MyCodeunit // Internal objects must include XML documentation comments [DC0008]
 {
     Access = Internal;

--- a/content/docs/analyzers/DocumentationCop/DC0009.md
+++ b/content/docs/analyzers/DocumentationCop/DC0009.md
@@ -1,0 +1,68 @@
++++
+title = 'Events must include XML documentation comments'
+linkTitle = 'DC0009'
+
+[params]
+  id = 'DC0009'
+  severity = 'Hidden'
+  category = 'Design'
+  codeAction = false
+  ignoreObsolete = true
++++
+
+A developer adds an event procedure to a codeunit and decorates it with `[IntegrationEvent(false, false)]` or `[BusinessEvent(false, false)]`, assuming the event name and parameters will be self-explanatory. For consumers of the extension — especially those without access to the source code — the event appears in IntelliSense with no description, no parameter hints, and no information about when it is raised or how it should be handled. They are left to guess at its purpose, preconditions, and guarantees.
+
+Add [XML documentation comments](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments) to describe the event, its parameters, and its intended usage, or remove the event if it is not meant to be part of the public API.
+
+### Example
+
+The following event is exposed as an integration event and lacks XML documentation:
+
+{{< highlight al "hl_lines=4" >}}
+codeunit 50100 MyCodeunit
+{
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCalculateTotal(Quantity: Decimal; UnitPrice: Decimal; var IsHandled: Boolean) // Events must include XML documentation comments [DC0009]
+    begin
+    end;
+}
+{{< /highlight >}}
+
+Add XML documentation to describe when the event is raised and how subscribers should use it:
+
+{{< highlight al "hl_lines=4-10" >}}
+codeunit 50100 MyCodeunit
+{
+    /// <summary>
+    /// Raised before the total price is calculated, allowing subscribers to override the default calculation.
+    /// </summary>
+    /// <param name="Quantity">The number of units used in the calculation.</param>
+    /// <param name="UnitPrice">The price per unit used in the calculation.</param>
+    /// <param name="IsHandled">
+    /// Set to <c>true</c> by subscribers to indicate that the calculation has been handled and the default logic should be skipped.
+    /// </param>
+    [IntegrationEvent(false, false)]
+    procedure OnBeforeCalculateTotal(Quantity: Decimal; UnitPrice: Decimal; var IsHandled: Boolean)
+    begin
+    end;
+}
+{{< /highlight >}}
+
+### When the diagnostic is reported
+
+- The procedure is decorated with `[IntegrationEvent()]` or `[BusinessEvent()]`.
+- The procedure has no XML documentation comments.
+- The containing object has an accessibility of `Public`.
+
+### Code documentation comments
+
+The AL Language extension has built-in IntelliSense support for [XML documentation comments](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments): typing `///` above an event procedure generates a template with `<summary>` and `<param>` tags matching the signature. Code documentation comments are available since [Business Central 2020 Release Wave 2 (version 17)](https://learn.microsoft.com/en-us/previous-versions/dynamics365-release-plan/2020wave2/smb/dynamics365-business-central/code-documentation-comments).
+
+### Exception
+
+Test codeunits (`Subtype = Test`) are exempt. Event procedures in test codeunits do not require XML documentation.
+
+### See also
+
+- [DC0006](../dc0006/) — Internal procedures must include XML documentation comments
+- [DC0010](../dc0010/) — Internal events must include XML documentation comments

--- a/content/docs/analyzers/DocumentationCop/DC0010.md
+++ b/content/docs/analyzers/DocumentationCop/DC0010.md
@@ -1,0 +1,70 @@
++++
+title = 'Internal events must include XML documentation comments'
+linkTitle = 'DC0010'
+
+[params]
+  id = 'DC0010'
+  severity = 'Hidden'
+  category = 'Design'
+  codeAction = false
+  ignoreObsolete = true
++++
+
+A developer adds an internal event procedure to a codeunit and decorates it with `[InternalEvent(false)]`, expecting the event name and parameters to speak for themselves. For consumers of the extension — including other extensions that can see internal members via `InternalsVisibleTo` — the event appears in IntelliSense with no description, no parameter hints, and no guidance on when it is raised or how it should be handled.
+
+Add [XML documentation comments](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments) to describe the event, or restrict it to `local` scope if it is not meant to be part of the internal API surface.
+
+### Example
+
+The following event is internal and lacks XML documentation:
+
+{{< highlight al "hl_lines=4" >}}
+codeunit 50100 MyCodeunit
+{
+    [InternalEvent(false)]
+    local procedure OnBeforeCalculateInternalTotal(Quantity: Decimal; UnitPrice: Decimal; var IsHandled: Boolean) // Internal events must include XML documentation comments [DC0010]
+    begin
+    end;
+}
+{{< /highlight >}}
+
+Add XML documentation to describe the event's purpose and parameters:
+
+{{< highlight al "hl_lines=4-10" >}}
+codeunit 50100 MyCodeunit
+{
+    /// <summary>
+    /// Raised before an internal total calculation is performed, allowing internal subscribers to override the default logic.
+    /// </summary>
+    /// <param name="Quantity">The number of units used in the internal calculation.</param>
+    /// <param name="UnitPrice">The price per unit used in the internal calculation.</param>
+    /// <param name="IsHandled">
+    /// Set to <c>true</c> by subscribers to indicate that the internal calculation has been handled and the default logic should be skipped.
+    /// </param>
+    [InternalEvent(false)]
+    local procedure OnBeforeCalculateInternalTotal(Quantity: Decimal; UnitPrice: Decimal; var IsHandled: Boolean)
+    begin
+    end;
+}
+{{< /highlight >}}
+
+If the event is not meant to be consumed by other objects, restrict its scope instead or limit or remove the `internalsVisibleTo` setting in your `app.json` file (see [app.json file](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-json-files#appjson-file)).
+
+### When the diagnostic is reported
+
+- The procedure is decorated with `[InternalEvent()]`.
+- The procedure has no XML documentation comments.
+- The containing object has an accessibility of `Public`.
+
+### Code documentation comments
+
+The AL Language extension has built-in IntelliSense support for [XML documentation comments](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-xml-comments): typing `///` above an event procedure generates a template with `<summary>` and `<param>` tags matching the signature. Code documentation comments are available since [Business Central 2020 Release Wave 2 (version 17)](https://learn.microsoft.com/en-us/previous-versions/dynamics365-release-plan/2020wave2/smb/dynamics365-business-central/code-documentation-comments).
+
+### Exception
+
+Test codeunits (`Subtype = Test`) are exempt. Internal event procedures in test codeunits do not require XML documentation.
+
+### See also
+
+- [DC0006](../dc0006/) — Internal procedures must include XML documentation comments
+- [DC0009](../dc0009/) — Events must include XML documentation comments

--- a/content/docs/analyzers/DocumentationCop/_index.md
+++ b/content/docs/analyzers/DocumentationCop/_index.md
@@ -13,5 +13,10 @@ The DocumentationCop ensures that AL code is properly documented and that non-ob
 | [DC0001](dc0001/) | Commit requires a comment explaining why | Info | ✓ | |
 | [DC0002](dc0002/) | Writing to a FlowField requires a comment explaining why | Info | ✓ | |
 | [DC0003](dc0003/) | Empty statements should be removed or documented | Info | ✓ | |
-| [DC0004](dc0004/) | Public procedures must have XML documentation | Info | ✓ | |
+| [DC0004](dc0004/) | Public procedures must include XML documentation comments | Info | ✓ | |
 | [DC0005](dc0005/) | XML documentation must match the procedure signature | Info | ✓ | |
+| [DC0006](dc0006/) | Internal procedures must include XML documentation comments | Hidden | ✓ | |
+| [DC0007](dc0007/) | Public objects must include XML documentation comments | Info | ✓ | |
+| [DC0008](dc0008/) | Internal objects must include XML documentation comments | Hidden | ✓ | |
+| [DC0009](dc0009/) | Events must include XML documentation comments | Hidden | ✓ | |
+| [DC0010](dc0010/) | Internal events must include XML documentation comments | Hidden | ✓ | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -814,9 +814,9 @@
       }
     },
     "node_modules/postcss-cli/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
[DC0006](https://alcops.dev/docs/analyzers/documentationcop/dc0006/): Internal procedures must include XML documentation comments
[DC0007](https://alcops.dev/docs/analyzers/documentationcop/dc0007/): Public objects must include XML documentation comments
[DC0008](https://alcops.dev/docs/analyzers/documentationcop/dc0008/): Internal objects must include XML documentation comments
[DC0009](https://alcops.dev/docs/analyzers/documentationcop/dc0009/): Events must must include XML documentation comments
[DC0010](https://alcops.dev/docs/analyzers/documentationcop/dc0010/): Internal events must include XML documentation comments
