### PR TITLE
AC0014 ToolTip Punctuation, LC0092 LocalVariable, GlobalVariable, VarParameter

### DIFF
--- a/content/docs/analyzers/ApplicationCop/AC0014.md
+++ b/content/docs/analyzers/ApplicationCop/AC0014.md
@@ -1,5 +1,5 @@
 +++
-title = 'ToolTip must end with a dot'
+title = 'ToolTip must end with a punctuation'
 linkTitle = 'AC0014'
 
 [params]
@@ -12,6 +12,8 @@ linkTitle = 'AC0014'
 
 ToolTips in Business Central follow a consistent sentence structure — all [examples in the user assistance guidelines](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/user-assistance#guidelines-for-tooltip-text) end with a dot. A ToolTip without trailing punctuation breaks that consistency, making the extension's UI feel unpolished against the standard application.
 
+By default this rule enforces a trailing dot. The allowed punctuation characters can be configured via `ToolTipAllowedPunctuations` in `alcops.json`.
+
 ### Example
 
 {{< highlight al "hl_lines=7" >}}
@@ -21,13 +23,13 @@ table 50100 "Item Category"
     {
         field(1; "Code"; Code[20])
         {
-            ToolTip = 'Specifies the code of the item category'; // ToolTip must end with a dot [AC0014]
+            ToolTip = 'Specifies the code of the item category'; // ToolTip must end with one of the following punctuations: 'dot' [AC0014]
         }
     }
 }
 {{< /highlight >}}
 
-Add a dot at the end of the ToolTip:
+Add the required punctuation at the end of the ToolTip:
 
 {{< highlight al "hl_lines=7" >}}
 table 50100 "Item Category"
@@ -41,6 +43,21 @@ table 50100 "Item Category"
     }
 }
 {{< /highlight >}}
+
+### Configuration
+
+The set of accepted ending punctuation characters can be changed in `alcops.json`. Each entry requires a `Character` (the literal punctuation) and a `Name` (used in the diagnostic message).
+
+When `ToolTipAllowedPunctuations` is omitted, the rule falls back to requiring a dot (`.`).
+
+```json
+{
+  "ToolTipAllowedPunctuations": [
+    { "Character": ".", "Name": "dot" },
+    { "Character": "!", "Name": "exclamation mark" }
+  ]
+}
+```
 
 ### See also
 

--- a/content/docs/analyzers/ApplicationCop/_index.md
+++ b/content/docs/analyzers/ApplicationCop/_index.md
@@ -23,7 +23,7 @@ The ApplicationCop enforces Business Central application conventions and design 
 | [AC0011](ac0011/) | Captions must be defined on user-facing objects and controls | Info | ✓ | |
 | [AC0012](ac0012/) | Integration events must not be declared in codeunits with Access set to Internal | Warning | ✓ | ✓ |
 | [AC0013](ac0013/) | DropDown and Brick fieldgroups must be defined | Info | — | |
-| [AC0014](ac0014/) | ToolTip must end with a dot | Info | ✓ | |
+| [AC0014](ac0014/) | ToolTip must end with a punctuation | Info | ✓ | |
 | [AC0015](ac0015/) | ToolTip should start with Specifies | Info | ✓ | |
 | [AC0016](ac0016/) | Do not use line breaks in ToolTip | Info | ✓ | |
 | [AC0017](ac0017/) | ToolTip should not exceed 200 characters | Info | ✓ | |

--- a/content/docs/analyzers/LinterCop/LC0092.md
+++ b/content/docs/analyzers/LinterCop/LC0092.md
@@ -117,6 +117,7 @@ Inheritance follows these chains (from specific to general):
 - LocalVariable, GlobalVariable -> Variable
 - Parameter -> LocalVariable -> Variable
 - VarParameter -> Parameter -> LocalVariable -> Variable
+- ReturnValue -> LocalVariable -> Variable
 
 When resolving patterns, the rule always uses the closest configured target in the chain (own override first, then parent overrides, then built-in defaults).
 

--- a/content/docs/analyzers/LinterCop/LC0092.md
+++ b/content/docs/analyzers/LinterCop/LC0092.md
@@ -47,8 +47,11 @@ The rule checks the following naming targets, each with a default convention:
 | GlobalProcedure | (inherits Procedure) | Non-local, non-event procedures |
 | EventSubscriber | (inherits Procedure) | Methods with `[EventSubscriber]` |
 | EventDeclaration | (inherits Procedure) | Methods with `[IntegrationEvent]` or `[BusinessEvent]` |
-| Variable | Must start with an uppercase letter, underscore followed by uppercase, or x followed by uppercase for xRec pattern (single-letter names are exempt); must not contain %, &, !, ? | Local and global variables |
-| Parameter | Must start with an uppercase letter, underscore followed by uppercase, or x followed by uppercase for xRec pattern (single-letter names are exempt) | Procedure parameters |
+| Variable | Must start with an uppercase letter, underscore followed by uppercase, or x followed by uppercase for xRec pattern (single-letter names are exempt); must not contain %, &, !, ? | Parent fallback target for variable-related targets |
+| LocalVariable | Must start with an uppercase letter, underscore followed by uppercase, or x followed by uppercase for xRec pattern (single-letter names are exempt); must not contain %, &, !, ? | Local variables |
+| GlobalVariable | Must start with an uppercase letter, underscore followed by uppercase, or x followed by uppercase for xRec pattern (single-letter names are exempt); must not contain %, &, !, ? | Global variables |
+| Parameter | Must start with an uppercase letter, underscore followed by uppercase, or x followed by uppercase for xRec pattern (single-letter names are exempt) | Non-var procedure parameters |
+| VarParameter | Must start with an uppercase letter, underscore followed by uppercase, or x followed by uppercase for xRec pattern (single-letter names are exempt) | `var` procedure parameters |
 | ReturnValue | Must start with an uppercase letter | Named return values |
 | Object | Must start with an uppercase letter | Tables, pages, codeunits, reports, queries, XmlPorts, enums, interfaces, permission sets |
 | Field | Must start with a letter (upper or lower); must not contain %, &, !, ? | Table fields |
@@ -106,12 +109,38 @@ Override default patterns or add custom patterns in `alcops.json`:
 }
 ```
 
-Only targets you specify are overridden. Unspecified targets keep the built-in defaults. Sub-targets (LocalProcedure, GlobalProcedure, EventSubscriber, EventDeclaration) inherit from Procedure when not explicitly configured.
+Only targets you specify are overridden. Unspecified targets keep the built-in defaults.
+
+Inheritance follows these chains (from specific to general):
+
+- LocalProcedure, GlobalProcedure, EventSubscriber, EventDeclaration -> Procedure
+- LocalVariable, GlobalVariable -> Variable
+- Parameter -> LocalVariable -> Variable
+- VarParameter -> Parameter -> LocalVariable -> Variable
+
+When resolving patterns, the rule always uses the closest configured target in the chain (own override first, then parent overrides, then built-in defaults).
 
 In the example above:
 
 - **Procedure** enforces strict PascalCase (letters and digits only, no spaces or special characters) and disallows underscores in procedure names.
 - **Variable** disallows Hungarian notation prefixes. The pattern catches common scope-type prefix combinations like `grec` (global record), `lrec` (local record), `gtxt` (global text), `lint` (local integer), etc.
+
+You can also override sub-targets directly when you need different conventions, for example stricter rules for local variables or separate rules for `var` parameters:
+
+```json
+{
+    "NamingPatterns": {
+        "LocalVariable": {
+            "DisallowPattern": "^_",
+            "DisallowDescription": "should not start with underscore"
+        },
+        "VarParameter": {
+            "AllowPattern": "^Ref[A-Z]",
+            "AllowDescription": "should start with Ref followed by PascalCase"
+        }
+    }
+}
+```
 
 **AllowDescription / DisallowDescription**: Optional human-readable description shown in the diagnostic message instead of the raw regex pattern. Should start with "should" or "should not". When omitted, the rule auto-generates a description for common patterns or falls back to showing the regex.
 


### PR DESCRIPTION
# AC0014: Make allowed ToolTip ending punctuation configurable

The current implementation of [AC0014](https://alcops.dev/docs/analyzers/applicationcop/ac0014/) hardcodes a trailing dot as the only accepted ToolTip ending. Some teams use different punctuation conventions (e.g. exclamation marks in specific locales or house styles).

**Changes:**
- The rule is renamed from _ToolTip must end with a dot_ to _ToolTip must end with a punctuation_.
- A new `ToolTipAllowedPunctuations` setting in `alcops.json` accepts an array of `{ Character, Name }` objects that define which punctuation characters are accepted.
- Default behavior is unchanged: when the setting is absent, a trailing dot is required.
- The diagnostic message now includes the configured punctuation names so users receive actionable feedback.

# LC0092: Add variable/parameter sub-target resolution with inheritance fallback

Changes:
- Add new naming targets:
  - LocalVariable
  - GlobalVariable
  - VarParameter
- Update symbol dispatch:
  - Local variable symbols -> LocalVariable
  - Global variable symbols -> GlobalVariable
  - Non-var parameters -> Parameter
  - var parameters -> VarParameter
- Add inheritance fallback for new target area:
  - LocalVariable -> Variable
  - GlobalVariable -> Variable
  - Parameter -> LocalVariable -> Variable
  - VarParameter -> Parameter -> LocalVariable -> Variable
- Keep resolution priority:
  - nearest user override first
  - then nearest built-in default

