### PR TITLE
feat: add PC0038 and LC0097 return-flow diagnostics

### DIFF
--- a/content/docs/analyzers/ApplicationCop/AC0030.md
+++ b/content/docs/analyzers/ApplicationCop/AC0030.md
@@ -86,6 +86,8 @@ Affected methods:
 
 ### See also
 
+- [LC0097](../../lintercop/lc0097/) - Avoid mixing exit() and named return variable assignments
+- [PC0038](../../platformcop/pc0038/) - Not all code paths return a value
 - [Record.Get() Method](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/methods-auto/record/record-get-method) on Microsoft Learn
 - [Get, Find, and Next Methods](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-get-find-and-next-methods) on Microsoft Learn
 - [if not then exit](https://alguidelines.dev/docs/bestpractices/if-not-find-then-exit/) on alguidelines.dev

--- a/content/docs/analyzers/LinterCop/LC0097.md
+++ b/content/docs/analyzers/LinterCop/LC0097.md
@@ -4,7 +4,7 @@ linkTitle = 'LC0097'
 
 [params]
   id = 'LC0097'
-  severity = 'Warning'
+  severity = 'Info'
   category = 'Usage'
   codeAction = false
   ignoreObsolete = true

--- a/content/docs/analyzers/LinterCop/LC0097.md
+++ b/content/docs/analyzers/LinterCop/LC0097.md
@@ -69,7 +69,5 @@ The rule is reported when all of the following are true:
 ### See also
 
 - [PC0038](../../platformcop/pc0038/) - Not all code paths return a value
-- [AC0030](../../applicationcop/ac0030/) - Use return value for better error handling
 - [Working with AL methods - Return values and named return variables](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-methods#declaring-methods) on Microsoft Learn
 - [AL control statements - Exit statement](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-control-statements#exit-statement) on Microsoft Learn
-- [AL complex types](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-complextypes) on Microsoft Learn

--- a/content/docs/analyzers/LinterCop/LC0097.md
+++ b/content/docs/analyzers/LinterCop/LC0097.md
@@ -1,0 +1,75 @@
++++
+title = 'Avoid mixing exit() and named return variable assignments'
+linkTitle = 'LC0097'
+
+[params]
+  id = 'LC0097'
+  severity = 'Warning'
+  category = 'Usage'
+  codeAction = false
+  ignoreObsolete = true
++++
+
+In procedures (and triggers) with a named return variable, use one return style consistently:
+
+- Assign to the named return variable and let the declaration end normally, or
+- Return using `exit(<value>)`
+
+Mixing both styles in the same declaration makes control flow harder to follow and increases the risk of accidental default returns.
+
+This diagnostic is disabled by default. Enable `LC0097` in your ruleset when you want to enforce a single return style.
+
+### Example
+
+This procedure mixes both styles:
+
+{{< highlight al "hl_lines=6" >}}
+procedure [|Compute|](UseFallback: Boolean) Result: Integer
+begin
+    Result := 10;
+
+    if UseFallback then
+        [|exit(20);|]
+end;
+{{< /highlight >}}
+
+Use one style consistently. Example using only the named return variable:
+
+{{< highlight al "hl_lines=3 6" >}}
+procedure Compute(UseFallback: Boolean) Result: Integer
+begin
+    Result := 10;
+
+    if UseFallback then
+        Result := 20;
+end;
+{{< /highlight >}}
+
+Alternative style using only `exit(<value>)`:
+
+{{< highlight al "hl_lines=4 6" >}}
+procedure Compute(UseFallback: Boolean): Integer
+begin
+    if UseFallback then
+        exit(20)
+    else
+        exit(10);
+end;
+{{< /highlight >}}
+
+### When the diagnostic is reported
+
+The rule is reported when all of the following are true:
+
+- The declaration has a named return variable
+- There is at least one assignment to that named return variable
+- There is at least one `exit` statement
+- The declaration is not marked with `TryFunction`
+
+### See also
+
+- [PC0038](../../platformcop/pc0038/) - Not all code paths return a value
+- [AC0030](../../applicationcop/ac0030/) - Use return value for better error handling
+- [Working with AL methods - Return values and named return variables](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-methods#declaring-methods) on Microsoft Learn
+- [AL control statements - Exit statement](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-control-statements#exit-statement) on Microsoft Learn
+- [AL complex types](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-complextypes) on Microsoft Learn

--- a/content/docs/analyzers/LinterCop/LC0097.md
+++ b/content/docs/analyzers/LinterCop/LC0097.md
@@ -24,7 +24,7 @@ This diagnostic is disabled by default. Enable `LC0097` in your ruleset when you
 This procedure mixes both styles:
 
 {{< highlight al "hl_lines=6" >}}
-procedure [|Compute|](UseFallback: Boolean) Result: Integer
+procedure Compute(UseFallback: Boolean) Result: Integer
 begin
     Result := 10;
 

--- a/content/docs/analyzers/LinterCop/LC0097.md
+++ b/content/docs/analyzers/LinterCop/LC0097.md
@@ -29,7 +29,7 @@ begin
     Result := 10;
 
     if UseFallback then
-        [|exit(20);|]
+        exit(20);
 end;
 {{< /highlight >}}
 

--- a/content/docs/analyzers/LinterCop/_index.md
+++ b/content/docs/analyzers/LinterCop/_index.md
@@ -39,3 +39,4 @@ The LinterCop is a code linter for AL, comparable to widely used static analysis
 | [LC0094](lc0094/) | AllowInCustomizations redundancy | Warning | ✓ | ✓ |
 | [LC0095](lc0095/) | Parameter is not referenced | Warning | ✓ | ✓ |
 | [LC0096](lc0096/) | Unnecessary record parameter in method call | Warning | ✓ | |
+| [LC0097](lc0097/) | Avoid mixing exit() and named return variable assignments | Warning | — | |

--- a/content/docs/analyzers/LinterCop/_index.md
+++ b/content/docs/analyzers/LinterCop/_index.md
@@ -39,4 +39,4 @@ The LinterCop is a code linter for AL, comparable to widely used static analysis
 | [LC0094](lc0094/) | AllowInCustomizations redundancy | Warning | ✓ | ✓ |
 | [LC0095](lc0095/) | Parameter is not referenced | Warning | ✓ | ✓ |
 | [LC0096](lc0096/) | Unnecessary record parameter in method call | Warning | ✓ | |
-| [LC0097](lc0097/) | Avoid mixing exit() and named return variable assignments | Warning | — | |
+| [LC0097](lc0097/) | Avoid mixing exit() and named return variable assignments | Info | — | |

--- a/content/docs/analyzers/PlatformCop/PC0038.md
+++ b/content/docs/analyzers/PlatformCop/PC0038.md
@@ -19,7 +19,7 @@ This rule flags declarations where not all code paths return a value.
 The following procedure misses a return value when the condition is false:
 
 {{< highlight al "hl_lines=5" >}}
-procedure [|GetAmount|](IncludeVat: Boolean): Decimal
+procedure GetAmount(IncludeVat: Boolean): Decimal
 begin
     if IncludeVat then
         exit(AmountInclVat);
@@ -85,8 +85,6 @@ Passing it by value (without `var`) does not count.
 
 ### See also
 
-- [AC0030](../../applicationcop/ac0030/) - Use return value for better error handling
 - [LC0097](../../lintercop/lc0097/) - Avoid mixing exit() and named return variable assignments
 - [Working with AL methods - Return values](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-methods#declaring-methods) on Microsoft Learn
 - [AL control statements - Exit statement](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-control-statements#exit-statement) on Microsoft Learn
-- [AL complex types](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-complextypes) on Microsoft Learn

--- a/content/docs/analyzers/PlatformCop/PC0038.md
+++ b/content/docs/analyzers/PlatformCop/PC0038.md
@@ -4,7 +4,7 @@ linkTitle = 'PC0038'
 
 [params]
   id = 'PC0038'
-  severity = 'Warning'
+  severity = 'Info'
   category = 'Usage'
   codeAction = false
   ignoreObsolete = true

--- a/content/docs/analyzers/PlatformCop/PC0038.md
+++ b/content/docs/analyzers/PlatformCop/PC0038.md
@@ -1,0 +1,57 @@
++++
+title = 'Not all code paths return a value'
+linkTitle = 'PC0038'
+
+[params]
+  id = 'PC0038'
+  severity = 'Warning'
+  category = 'Usage'
+  codeAction = false
+  ignoreObsolete = true
++++
+
+Procedures with a return type must produce a value on every reachable path. If one branch falls through without returning a value, AL can end up returning an implicit default value (`0`, `false`, empty text), which hides logic bugs and makes behavior harder to reason about.
+
+This rule flags declarations where not all code paths return a value.
+
+### Example
+
+The following procedure misses a return value when the condition is false:
+
+{{< highlight al "hl_lines=5" >}}
+procedure [|GetAmount|](IncludeVat: Boolean): Decimal
+begin
+    if IncludeVat then
+        exit(AmountInclVat);
+end;
+{{< /highlight >}}
+
+Return a value on all paths:
+
+{{< highlight al "hl_lines=5-7" >}}
+procedure GetAmount(IncludeVat: Boolean): Decimal
+begin
+    if IncludeVat then
+        exit(AmountInclVat)
+    else
+        exit(AmountExclVat);
+end;
+{{< /highlight >}}
+
+### When the diagnostic is reported
+
+The rule is reported when all of the following are true:
+
+- The declaration is a procedure with an explicit return type
+- At least one reachable path can end without returning a value
+- The declaration is not marked with `TryFunction`
+
+Triggers are intentionally excluded from this rule, even when they declare a return type.
+
+### See also
+
+- [AC0030](../../applicationcop/ac0030/) - Use return value for better error handling
+- [LC0097](../../lintercop/lc0097/) - Avoid mixing exit() and named return variable assignments
+- [Working with AL methods - Return values](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-methods#declaring-methods) on Microsoft Learn
+- [AL control statements - Exit statement](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-control-statements#exit-statement) on Microsoft Learn
+- [AL complex types](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/developer/devenv-al-complextypes) on Microsoft Learn

--- a/content/docs/analyzers/PlatformCop/PC0038.md
+++ b/content/docs/analyzers/PlatformCop/PC0038.md
@@ -48,6 +48,41 @@ The rule is reported when all of the following are true:
 
 Triggers are intentionally excluded from this rule, even when they declare a return type.
 
+### Exception
+
+Paths that end with `Error(...)` are accepted:
+
+{{< highlight al >}}
+procedure GetAmount(IncludeVat: Boolean): Decimal
+begin
+    if IncludeVat then
+        exit(AmountInclVat)
+    else
+        Error('Prices without VAT are not supported.');
+end;
+{{< /highlight >}}
+
+A named return variable passed to a `var` parameter, or used as the receiver of a call, counts as assigned:
+
+{{< highlight al >}}
+procedure BuildGreeting() Greeting: Text
+begin
+    GetGreeting(Greeting);
+end;
+
+local procedure GetGreeting(var GreetingText: Text)
+begin
+    GreetingText := 'Hello';
+end;
+
+procedure FindCustomer(CustomerNo: Code[20]) Customer: Record Customer
+begin
+    Customer.Get(CustomerNo);
+end;
+{{< /highlight >}}
+
+Passing it by value (without `var`) does not count.
+
 ### See also
 
 - [AC0030](../../applicationcop/ac0030/) - Use return value for better error handling

--- a/content/docs/analyzers/PlatformCop/_index.md
+++ b/content/docs/analyzers/PlatformCop/_index.md
@@ -46,4 +46,4 @@ The PlatformCop detects code that is technically broken, dangerous, or silently 
 | [PC0035](pc0035/) | Use SetAutoCalcFields for loops | Warning | ✓ | ✓ |
 | [PC0036](pc0036/) | SetRecord() does not support temporary records | Warning | ✓ | |
 | [PC0037](pc0037/) | Use Validate() instead of direct field assignment | Warning | ✓ | ✓ |
-| [PC0038](pc0038/) | Not all code paths return a value | Warning | ✓ | |
+| [PC0038](pc0038/) | Not all code paths return a value | Info | ✓ | |

--- a/content/docs/analyzers/PlatformCop/_index.md
+++ b/content/docs/analyzers/PlatformCop/_index.md
@@ -46,3 +46,4 @@ The PlatformCop detects code that is technically broken, dangerous, or silently 
 | [PC0035](pc0035/) | Use SetAutoCalcFields for loops | Warning | ✓ | ✓ |
 | [PC0036](pc0036/) | SetRecord() does not support temporary records | Warning | ✓ | |
 | [PC0037](pc0037/) | Use Validate() instead of direct field assignment | Warning | ✓ | ✓ |
+| [PC0038](pc0038/) | Not all code paths return a value | Warning | ✓ | |


### PR DESCRIPTION
# Feat: add PC0038 and LC0097 return-flow diagnostics

## Summary

This PR adds documentation for two newly introduced analyzer features:

- PC0038 NotAllCodePathsReturnValue
- LC0097 MixedExitAndNamedReturnAssignment (disabled by default)

## What is new

- Added documentation pages for PC0038 and LC0097.
- Updated analyzer index/navigation entries so both rules are discoverable in the correct sections.
- Updated related cross-references

## Outcome

Documentation is now aligned with the new analyzer feature set and provides clear guidance for adoption and interpretation of PC0038 and LC0097.

See discussion [Warning/error if procedure with return value doesn't contain exit() and doesn't assign to the named return value](https://github.com/ALCops/Analyzers/discussions/362#discussion-10311249).