### PR TITLE
feat(LC0095,LC0099): split unreferenced-parameter rule into LC0095 and LC0099

### DIFF
--- a/content/docs/analyzers/LinterCop/LC0095.md
+++ b/content/docs/analyzers/LinterCop/LC0095.md
@@ -10,7 +10,7 @@ linkTitle = 'LC0095'
   ignoreObsolete = true
 +++
 
-CodeCop [AA0137](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137) detects unreferenced parameters only in local procedures and explicitly excludes event subscribers. LC0095 covers the gaps: internal procedures, public procedures, and event subscribers.
+CodeCop [AA0137](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137) detects unreferenced parameters only in local procedures and explicitly excludes event subscribers. LC0095 covers the non-local, non-subscriber gaps: internal procedures and public procedures.
 
 A parameter that is never referenced in the procedure body clutters the signature, misleads callers about what the procedure needs, and creates unnecessary coupling. Removing it simplifies both the definition and every call site.
 
@@ -36,25 +36,10 @@ codeunit 50100 MyCodeunit
 }
 {{< /highlight >}}
 
-### Event subscriber example
-
-Event subscribers often declare all the event's parameters but only use a subset. The event infrastructure allocates and populates every declared parameter at each invocation, even the ones the subscriber never reads.
-
-{{< highlight al "hl_lines=4" >}}
-codeunit 50100 MyCodeunit
-{
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Post", OnBeforePostSalesDoc, '', false, false)]
-    local procedure OnBeforePostSalesDoc(var SalesHeader: Record "Sales Header"; var IsHandled: Boolean) // Parameter 'SalesHeader' is not referenced in procedure 'OnBeforePostSalesDoc'. [LC0095]
-    begin
-        IsHandled := true;
-    end;
-}
-{{< /highlight >}}
 ### Covered by this rule
 
 - Internal procedures
 - Public procedures
-- Event subscribers
 
 ### Excluded from this rule
 
@@ -72,7 +57,7 @@ codeunit 50100 MyCodeunit
 | Local procedures | ✅ | ❌ (defers to AA0137) |
 | Internal procedures | ❌ | ✅ |
 | Public procedures | ❌ | ✅ |
-| Event subscribers | ❌ | ✅ |
+| Event subscribers | ❌ | ❌ (covered by [LC0099](../lc0099/)) |
 | Triggers | ❌ | ❌ |
 | Interface implementations | ❌ | ❌ |
 | Event declarations | ❌ | ❌ |
@@ -80,5 +65,6 @@ codeunit 50100 MyCodeunit
 ### See also
 
 - [AA0137 - Do not declare variables that are unused](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137)
+- [LC0099](../lc0099/) - Event subscriber parameter is not referenced
 - [LC0052](../lc0052/) - Internal procedure not referenced
 - [LC0053](../lc0053/) - Internal procedure only used in current object

--- a/content/docs/analyzers/LinterCop/LC0099.md
+++ b/content/docs/analyzers/LinterCop/LC0099.md
@@ -1,0 +1,70 @@
++++
+title = 'Event subscriber parameter is not referenced'
+linkTitle = 'LC0099'
+
+[params]
+  id = 'LC0099'
+  severity = 'Info'
+  category = 'Design'
+  codeAction = true
+  ignoreObsolete = true
++++
+
+CodeCop [AA0137](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137) explicitly excludes event subscribers, and [LC0095](../lc0095/) covers non-local non-subscriber procedures. LC0099 fills the remaining subscriber-specific gap and reports unreferenced event subscriber parameters.
+
+Event subscribers are often scaffolded with all event parameters, but implementations frequently need only a subset. Keeping only the parameters you actually use makes intent clearer and can reduce unnecessary data flow through subscriber signatures.
+
+### Example
+
+{{< highlight al "hl_lines=4" >}}
+codeunit 50100 MyCodeunit
+{
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Post", OnBeforePostSalesDoc, '', false, false)]
+    local procedure OnBeforePostSalesDoc(var SalesHeader: Record "Sales Header"; var IsHandled: Boolean) // Parameter 'SalesHeader' is not referenced in event subscriber 'OnBeforePostSalesDoc'. [LC0099]
+    begin
+        IsHandled := true;
+    end;
+}
+{{< /highlight >}}
+
+Fixed:
+
+{{< highlight al "hl_lines=4" >}}
+codeunit 50100 MyCodeunit
+{
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Post", OnBeforePostSalesDoc, '', false, false)]
+    local procedure OnBeforePostSalesDoc(var IsHandled: Boolean)
+    begin
+        IsHandled := true;
+    end;
+}
+{{< /highlight >}}
+
+### Covered by this rule
+
+- Event subscribers
+
+### Excluded from this rule
+
+- **Local procedures** (AA0137 handles them)
+- **Internal procedures** (covered by [LC0095](../lc0095/))
+- **Public procedures** (covered by [LC0095](../lc0095/))
+- **Triggers** (platform-defined signatures, cannot be changed)
+- **Interface implementations** (bound by interface contract)
+- **Event declarations** (`[IntegrationEvent]`/`[BusinessEvent]`, parameters define the subscriber contract)
+- **Obsolete procedures** (pending or removed, not worth modifying)
+
+### Severity rationale
+
+LC0099 is reported as **Info**. Many teams keep generated subscriber signatures as-is, while others prefer trimming to used parameters only. Info severity provides guidance without forcing warning-level enforcement.
+
+### Fix behavior
+
+The code action removes the unreferenced parameter from the subscriber signature.
+
+Fix All is supported and scoped to event subscribers via the rule-specific equivalence key, so batch fixes do not affect non-subscriber procedures.
+
+### See also
+
+- [AA0137 - Do not declare variables that are unused](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/codecop-aa0137)
+- [LC0095](../lc0095/) - Parameter is not referenced

--- a/content/docs/analyzers/LinterCop/_index.md
+++ b/content/docs/analyzers/LinterCop/_index.md
@@ -40,3 +40,4 @@ The LinterCop is a code linter for AL, comparable to widely used static analysis
 | [LC0095](lc0095/) | Parameter is not referenced | Warning | ✓ | ✓ |
 | [LC0096](lc0096/) | Unnecessary record parameter in method call | Warning | ✓ | |
 | [LC0097](lc0097/) | Avoid mixing exit() and named return variable assignments | Info | — | |
+| [LC0099](lc0099/) | Event subscriber parameter is not referenced | Info | ✓ | ✓ |


### PR DESCRIPTION
Separate unreferenced parameter diagnostics:
- Keep LC0095 for regular non-local procedures (internal/public)
- Introduce LC0099 for event subscribers (Info severity)

Update documentation and guidance:
- Update LC0095 instruction/documentation to reflect reduced scope
- Add LC0099 instruction/documentation with rationale and examples
- Update LinterCop index to include LC0099